### PR TITLE
[WIP] Fuse activation functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxLib"
 uuid = "82251201-b29d-42c6-8e01-566dec8acb11"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.1.13"
+version = "0.1.14"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/LuxLib.jl
+++ b/src/LuxLib.jl
@@ -30,6 +30,7 @@ include("utils.jl")
 include("deprecated.jl")
 
 # Low-Level Implementations
+include("impl/activations.jl")
 include("impl/groupnorm.jl")
 include("impl/normalization.jl")
 
@@ -40,7 +41,14 @@ include("api/groupnorm.jl")
 include("api/instancenorm.jl")
 include("api/layernorm.jl")
 
+# Activation Functions
+export GenericActivationFunction, IdentityActivationFunction,
+       InputFreeGradientActivationFunction, activation_function
+
+# Normalization
 export batchnorm, groupnorm, instancenorm, layernorm
+
+# Dropout
 export alpha_dropout, dropout
 
 end

--- a/src/impl/activations.jl
+++ b/src/impl/activations.jl
@@ -1,0 +1,74 @@
+"""
+    activation_function(f)
+    activation_function(f, Δf)
+
+Turn an activation function into an `AbstractActivationFunction` object. Allows for fusing
+activation functions with KA implementations.
+"""
+function activation_function end
+
+abstract type AbstractActivationFunction end
+
+Base.length(::AbstractActivationFunction) = 0
+
+struct GenericActivationFunction{F <: Function} <: AbstractActivationFunction
+    f::F
+end
+
+activation_function(f::Function) = GenericActivationFunction(f)
+
+(a::GenericActivationFunction)(x) = a.f(x)
+
+# Activation Functions for which we don't have to store the input
+abstract type AbstractInputFreeGradientActivationFunction <: AbstractActivationFunction end
+
+const AbstractIFGActFunction = AbstractInputFreeGradientActivationFunction
+
+struct IdentityActivationFunction <: AbstractInputFreeGradientActivationFunction end
+struct InputFreeGradientActivationFunction{F1 <: Function, F2 <: Function} <:
+       AbstractInputFreeGradientActivationFunction
+    f::F1
+    Δf::F2
+end
+
+activation_function(::typeof(identity)) = IdentityActivationFunction()
+activation_function(f, ::Nothing) = activation_function(f)
+activation_function(f, Δf) = InputFreeGradientActivationFunction(f, Δf)
+
+(a::AbstractInputFreeGradientActivationFunction)(x) = ₋₋forward(a, x)
+(a::AbstractInputFreeGradientActivationFunction)(Δ, y) = ₋₋backward(a, Δ, y)
+
+@inline ₋₋forward(::IdentityActivationFunction, x) = x
+@inline ₋₋forward(f::InputFreeGradientActivationFunction, x) = f.f(x)
+
+@inline ₋₋backward(::IdentityActivationFunction, Δ, _) = Δ
+@inline ₋₋backward(f::InputFreeGradientActivationFunction, Δ, Ω) = f.Δf(Ω) * Δ
+
+function CRC.rrule(::typeof(₋₋forward), a::AbstractInputFreeGradientActivationFunction, x)
+    Ω = a(x)
+    ₋₋forward_pullback(Δ) = (NoTangent(), NoTangent(), ₋₋backward(a, Δ, Ω))
+    return Ω, ₋₋forward_pullback
+end
+
+# https://github.com/FluxML/NNlib.jl/blob/5a1c42c8f23b0e45cea77714b84fd231e25897aa/src/activations.jl#L856
+SUPPORTED_INPUT_FREE_GRADIENT_ACTIVATIONS = [
+    (:σ, :(conj(Ω * (1 - Ω)))),
+    (:hardσ, :(ifelse((Ω > 0) & (Ω < 1), oftf(Ω, 1 / 6), oftf(Ω, 1)))),
+    (:hardtanh, :((Ω > -1) & (Ω < 1))),
+    (:relu, :(Ω > 0)),
+    (:relu6, :((Ω > 0) & (Ω < 6))),
+    (:elu, :(NNlib.deriv_elu(Ω))),
+    (:selu, :(NNlib.deriv_selu(Ω))),
+    (:celu, :(NNlib.deriv_celu(Ω))),
+    (:trelu, :(Ω > 0)),
+    (:softshrink, :(Ω != 0)),
+    (:tanh, :(conj(1 - Ω^2))),
+    (:tanh_fast, :(conj(1 - Ω^2))),
+    (:sigmoid_fast, :(conj(Ω * (1 - Ω)))),
+]
+
+for (f, dfdx) in SUPPORTED_INPUT_FREE_GRADIENT_ACTIVATIONS
+    @eval function activation_function(::typeof($f))
+        return InputFreeGradientActivationFunction($f, Ω -> $dfdx)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using SafeTestsets, Test
 
 @testset "LuxLib" begin
+    @time @safetestset "Activations" begin include("impl/activations.jl") end
+
     @time @safetestset "Dropout" begin include("api/dropout.jl") end
 
     @time @safetestset "BatchNorm" begin include("api/batchnorm.jl") end


### PR DESCRIPTION
## TODOs

- [ ] Add documentation for the package
- [ ] Fix existing tests for tracker.jl
- [ ] Add tests for the activation functions

## Results

```julia
# Fused `relu`
julia> @benchmark Zygote.gradient((x, scale, bias) -> sum(LuxLib.groupnorm(x, scale, bias, $(activation_function(relu)); groups=32, epsilon=1f-5)), $x, $ps.scale, $ps.bias)
BenchmarkTools.Trial: 10 samples with 1 evaluation.
 Range (min … max):  496.698 ms … 551.185 ms  ┊ GC (min … max):  7.65% … 13.52%
 Time  (median):     535.511 ms               ┊ GC (median):    13.83%
 Time  (mean ± σ):   532.414 ms ±  16.744 ms  ┊ GC (mean ± σ):  12.59% ±  2.57%

  ▁             ▁                        ▁ ▁▁▁       ▁█       ▁  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁███▁▁▁▁▁▁▁██▁▁▁▁▁▁▁█ ▁
  497 ms           Histogram: frequency by time          551 ms <

 Memory estimate: 1.50 GiB, allocs estimate: 1298.

# Manual `relu`
julia> @benchmark Zygote.gradient((x, scale, bias) -> sum(relu.(LuxLib.groupnorm(x, scale, bias, $(activation_function(identity)); groups=32, epsilon=1f-5))), $x, $ps.scale, $ps.bias)
BenchmarkTools.Trial: 6 samples with 1 evaluation.
 Range (min … max):  817.932 ms … 899.197 ms  ┊ GC (min … max): 5.72% … 4.62%
 Time  (median):     843.501 ms               ┊ GC (median):    5.83%
 Time  (mean ± σ):   848.474 ms ±  28.949 ms  ┊ GC (mean ± σ):  5.78% ± 1.12%

  █     █          █  █          █                            █  
  █▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁█▁▁█▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  818 ms           Histogram: frequency by time          899 ms <

 Memory estimate: 2.50 GiB, allocs estimate: 1327.
```