### PR TITLE
Improvements to the fused operations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxLib"
 uuid = "82251201-b29d-42c6-8e01-566dec8acb11"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.3.17"
+version = "0.3.18"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [extensions]
 LuxLibAMDGPUExt = "AMDGPU"
+LuxLibCUDAExt = "CUDA"
 LuxLibForwardDiffExt = "ForwardDiff"
 LuxLibReverseDiffExt = "ReverseDiff"
 LuxLibTrackerAMDGPUExt = ["AMDGPU", "Tracker"]
@@ -41,7 +42,7 @@ LuxLibcuDNNExt = ["CUDA", "cuDNN"]
 AMDGPU = "0.8.4"
 Aqua = "0.8.7"
 ArrayInterface = "7.9"
-CUDA = "5.2"
+CUDA = "5.3.2"
 ChainRulesCore = "1.23"
 ComponentArrays = "0.15.8"
 ExplicitImports = "1.4.1"

--- a/ext/LuxLibCUDAExt/LuxLibCUDAExt.jl
+++ b/ext/LuxLibCUDAExt/LuxLibCUDAExt.jl
@@ -1,0 +1,34 @@
+module LuxLibCUDAExt
+
+# This file only wraps functionality part of CUDA like CUBLAS
+using CUDA: CUDA, CUBLAS, StridedCuMatrix, StridedCuVector, CuPtr
+using LinearAlgebra: LinearAlgebra, Transpose, Adjoint, mul!
+using LuxLib: LuxLib
+using NNlib: NNlib
+
+# Low level functions
+include("cublaslt.jl")
+
+# fused dense
+@inline __length(x) = length(x)
+@inline __length(::Nothing) = nothing
+
+function LuxLib.__fused_dense_bias_activation_impl(
+        act::F, weight::CUDA.AnyCuMatrix, x::CUDA.AnyCuMatrix,
+        b::Union{Nothing, CUDA.AnyCuVector}) where {F}
+    y = similar(x, LuxLib.__get_concrete_fba_output_eltype(act, weight, x, b),
+        size(weight, 1), size(x, 2))
+    if hasmethod(LuxLib._cublaslt_matmul_fused!,
+        (typeof(y), F, typeof(weight), typeof(x), typeof(b)))
+        retcode = LuxLib._cublaslt_matmul_fused!(y, act, weight, x, b)
+        retcode == 0 && return y
+        # cuBLASLt failed for the given inputs use the generic fallback
+        @warn "cuBLASLt failed for the given inputs $(act), $(typeof(weight)) \
+               [$(size(weight))], $(typeof(x)) [$(size(x))], $(typeof(b)) \
+               [$(__length(b))]. Falling back to generic implementation." maxlog=1
+    end
+    mul!(y, weight, x)
+    return LuxLib.__apply_bias_activation!!(act, y, b, Val(false))
+end
+
+end

--- a/ext/LuxLibCUDAExt/LuxLibCUDAExt.jl
+++ b/ext/LuxLibCUDAExt/LuxLibCUDAExt.jl
@@ -1,10 +1,10 @@
 module LuxLibCUDAExt
 
 # This file only wraps functionality part of CUDA like CUBLAS
-using CUDA: CUDA, CUBLAS, StridedCuMatrix, StridedCuVector, CuPtr
+using CUDA: CUDA, CUBLAS, StridedCuMatrix, StridedCuVector, CuPtr, AnyCuMatrix, AnyCuVector
 using ChainRulesCore: ChainRulesCore
 using FastClosures: @closure
-using LinearAlgebra: LinearAlgebra, Transpose, Adjoint, mul!
+using LinearAlgebra: LinearAlgebra, Transpose, Adjoint
 using LuxLib: LuxLib
 using NNlib: NNlib
 

--- a/ext/LuxLibCUDAExt/LuxLibCUDAExt.jl
+++ b/ext/LuxLibCUDAExt/LuxLibCUDAExt.jl
@@ -2,9 +2,12 @@ module LuxLibCUDAExt
 
 # This file only wraps functionality part of CUDA like CUBLAS
 using CUDA: CUDA, CUBLAS, StridedCuMatrix, StridedCuVector, CuPtr
+using ChainRulesCore: ChainRulesCore
 using LinearAlgebra: LinearAlgebra, Transpose, Adjoint, mul!
 using LuxLib: LuxLib
 using NNlib: NNlib
+
+const CRC = ChainRulesCore
 
 # Low level functions
 include("cublaslt.jl")

--- a/ext/LuxLibCUDAExt/LuxLibCUDAExt.jl
+++ b/ext/LuxLibCUDAExt/LuxLibCUDAExt.jl
@@ -3,6 +3,7 @@ module LuxLibCUDAExt
 # This file only wraps functionality part of CUDA like CUBLAS
 using CUDA: CUDA, CUBLAS, StridedCuMatrix, StridedCuVector, CuPtr
 using ChainRulesCore: ChainRulesCore
+using FastClosures: @closure
 using LinearAlgebra: LinearAlgebra, Transpose, Adjoint, mul!
 using LuxLib: LuxLib
 using NNlib: NNlib

--- a/ext/LuxLibCUDAExt/LuxLibCUDAExt.jl
+++ b/ext/LuxLibCUDAExt/LuxLibCUDAExt.jl
@@ -10,25 +10,6 @@ using NNlib: NNlib
 include("cublaslt.jl")
 
 # fused dense
-@inline __length(x) = length(x)
-@inline __length(::Nothing) = nothing
-
-function LuxLib.__fused_dense_bias_activation_impl(
-        act::F, weight::CUDA.AnyCuMatrix, x::CUDA.AnyCuMatrix,
-        b::Union{Nothing, CUDA.AnyCuVector}) where {F}
-    y = similar(x, LuxLib.__get_concrete_fba_output_eltype(act, weight, x, b),
-        size(weight, 1), size(x, 2))
-    if hasmethod(LuxLib._cublaslt_matmul_fused!,
-        (typeof(y), F, typeof(weight), typeof(x), typeof(b)))
-        retcode = LuxLib._cublaslt_matmul_fused!(y, act, weight, x, b)
-        retcode == 0 && return y
-        # cuBLASLt failed for the given inputs use the generic fallback
-        @warn "cuBLASLt failed for the given inputs $(act), $(typeof(weight)) \
-               [$(size(weight))], $(typeof(x)) [$(size(x))], $(typeof(b)) \
-               [$(__length(b))]. Falling back to generic implementation." maxlog=1
-    end
-    mul!(y, weight, x)
-    return LuxLib.__apply_bias_activation!!(act, y, b, Val(false))
-end
+include("fused_dense.jl")
 
 end

--- a/ext/LuxLibCUDAExt/cublaslt.jl
+++ b/ext/LuxLibCUDAExt/cublaslt.jl
@@ -1,0 +1,124 @@
+const TransOrAdjOrRegStridedCuMatrix{T} = Union{Transpose{T, <:StridedCuMatrix{T}},
+    Adjoint{T, <:StridedCuMatrix{T}}, StridedCuMatrix{T}}
+
+function LuxLib._cublaslt_matmul_fused!(
+        @nospecialize(y::TransOrAdjOrRegStridedCuMatrix{yT}), σ::F,
+        @nospecialize(w::TransOrAdjOrRegStridedCuMatrix{wT}),
+        @nospecialize(x::TransOrAdjOrRegStridedCuMatrix{xT}),
+        b::Union{Nothing, StridedCuVector}) where {F, yT, wT, xT}
+    transy = y isa Transpose || y isa Adjoint
+    transx = x isa Transpose || x isa Adjoint
+    transw = w isa Transpose || w isa Adjoint
+    return LuxLib._cublaslt_matmul_fused!(
+        transy, parent(y), σ, transw, parent(w), transx, parent(x), b)
+end
+
+# Returns: 0 if successful, -1 if unsuccessful
+function LuxLib._cublaslt_matmul_fused!(
+        transy::Bool, @nospecialize(y::StridedCuMatrix{yT}), σ::F,
+        transw::Bool, @nospecialize(w::StridedCuMatrix{wT}),
+        transx::Bool, @nospecialize(x::StridedCuMatrix{xT}),
+        b::Union{Nothing, StridedCuVector}) where {F, yT, wT, xT}
+    m = size(y, 1)
+    n = size(y, 2)
+    k = size(w, 2)
+
+    if b === nothing
+        size(y, transy ? 2 : 1) == size(w, transw ? 2 : 1) ||
+            throw(DimensionMismatch("size(y) = $(size(y)), size(w) = $(size(w))"))
+    else
+        size(y, transy ? 2 : 1) == size(w, transw ? 2 : 1) == size(b, 1) ||
+            throw(DimensionMismatch("size(y) = $(size(y)), size(w) = $(size(w)), size(b) = $(size(b))"))
+    end
+    size(x, transx ? 2 : 1) == size(w, transw ? 1 : 2) ||
+        throw(DimensionMismatch("size(x) = $(size(x)), size(w) = $(size(w))"))
+
+    # Create the operation descriptor
+    operationDesc = Ref{CUBLAS.cublasLtMatmulDesc_t}()
+    computeType = CUBLAS.gemmExComputeType(wT, xT, yT, m, k, n)
+    computeType === nothing && return -1
+    dataType = convert(CUDA.cudaDataType, yT)
+    CUBLAS.cublasLtMatmulDescCreate(operationDesc, computeType, dataType)
+
+    # Set the matrix descriptors
+    ytransop = transy ? CUBLAS.CUBLAS_OP_T : CUBLAS.CUBLAS_OP_N
+    wtransop = transw ? CUBLAS.CUBLAS_OP_T : CUBLAS.CUBLAS_OP_N
+    xtransop = transx ? CUBLAS.CUBLAS_OP_T : CUBLAS.CUBLAS_OP_N
+
+    CUBLAS.cublasLtMatmulDescSetAttribute(
+        operationDesc[], CUBLAS.CUBLASLT_MATMUL_DESC_TRANSA,
+        Ref{CUBLAS.cublasOperation_t}(wtransop), sizeof(wtransop))
+    CUBLAS.cublasLtMatmulDescSetAttribute(
+        operationDesc[], CUBLAS.CUBLASLT_MATMUL_DESC_TRANSB,
+        Ref{CUBLAS.cublasOperation_t}(xtransop), sizeof(xtransop))
+    CUBLAS.cublasLtMatmulDescSetAttribute(
+        operationDesc[], CUBLAS.CUBLASLT_MATMUL_DESC_TRANSC,
+        Ref{CUBLAS.cublasOperation_t}(ytransop), sizeof(ytransop))
+
+    # Decide on the epilogue
+    epilogue, activation_fused = __epilogue_act(σ, b)
+    CUBLAS.cublasLtMatmulDescSetAttribute(
+        operationDesc[], CUBLAS.CUBLASLT_MATMUL_DESC_EPILOGUE,
+        Ref{CUBLAS.cublasLtEpilogue_t}(epilogue), sizeof(epilogue))
+
+    # We have a bias so set the bias pointer
+    if b !== nothing
+        bias_ptr = Ref{CuPtr{Cvoid}}(pointer(b))
+        CUBLAS.cublasLtMatmulDescSetAttribute(
+            operationDesc[], CUBLAS.CUBLASLT_MATMUL_DESC_BIAS_POINTER,
+            bias_ptr, sizeof(bias_ptr))
+    end
+
+    # Create the matrix layouts
+    wdesc = Ref{CUBLAS.cublasLtMatrixLayout_t}()
+    xdesc = Ref{CUBLAS.cublasLtMatrixLayout_t}()
+    ydesc = Ref{CUBLAS.cublasLtMatrixLayout_t}()
+
+    CUBLAS.cublasLtMatrixLayoutCreate(
+        wdesc, convert(CUDA.cudaDataType, wT), m, k, max(1, stride(w, 2)))
+    CUBLAS.cublasLtMatrixLayoutCreate(
+        xdesc, convert(CUDA.cudaDataType, xT), k, n, max(1, stride(x, 2)))
+    CUBLAS.cublasLtMatrixLayoutCreate(
+        ydesc, convert(CUDA.cudaDataType, yT), m, n, max(1, stride(y, 2)))
+
+    # Create the preference. we can customize this but we will stick to the defaults
+    preference = Ref{CUBLAS.cublasLtMatmulPreference_t}()
+    CUBLAS.cublasLtMatmulPreferenceCreate(preference)
+
+    # Create the light handle
+    lthandle = Ref{CUBLAS.cublasLtHandle_t}()
+    CUBLAS.cublasLtCreate(lthandle)
+
+    # Seach for the best algorithm
+    heuristic = Ref{CUBLAS.cublasLtMatmulHeuristicResult_t}()
+    returnedResults = Ref{Cint}(0)
+    CUBLAS.cublasLtMatmulAlgoGetHeuristic(
+        lthandle[], operationDesc[], wdesc[], xdesc[], ydesc[],
+        ydesc[], preference[], 1, heuristic, returnedResults)
+
+    returnedResults[] == 0 && return -1
+
+    CUBLAS.cublasLtMatmul(lthandle[], operationDesc[], Ref{promote_type(wT, xT)}(1),
+        w, wdesc[], x, xdesc[], Ref{yT}(0), y, ydesc[], y, ydesc[],
+        Ref(heuristic[].algo), CUDA.CU_NULL, 0, CUDA.stream())
+
+    !activation_fused && (@. y = σ(y))
+
+    return 0
+end
+
+@inline __epilogue_act(::typeof(identity), ::Nothing) = (
+    CUBLAS.CUBLASLT_EPILOGUE_DEFAULT, true)
+@inline __epilogue_act(::typeof(identity), ::StridedCuVector) = (
+    CUBLAS.CUBLASLT_EPILOGUE_BIAS, true)
+@inline __epilogue_act(::typeof(NNlib.relu), ::Nothing) = (
+    CUBLAS.CUBLASLT_EPILOGUE_RELU, true)
+@inline __epilogue_act(::typeof(NNlib.relu), ::StridedCuVector) = (
+    CUBLAS.CUBLASLT_EPILOGUE_RELU_BIAS, true)
+@inline __epilogue_act(::typeof(NNlib.gelu), ::Nothing) = (
+    CUBLAS.CUBLASLT_EPILOGUE_GELU, true)
+@inline __epilogue_act(::typeof(NNlib.gelu), ::StridedCuVector) = (
+    CUBLAS.CUBLASLT_EPILOGUE_GELU_BIAS, true)
+@inline __epilogue_act(::F, ::Nothing) where {F} = (CUBLAS.CUBLASLT_EPILOGUE_DEFAULT, false)
+@inline __epilogue_act(::F, ::StridedCuVector) where {F} = (
+    CUBLAS.CUBLASLT_EPILOGUE_BIAS, false)

--- a/ext/LuxLibCUDAExt/cublaslt.jl
+++ b/ext/LuxLibCUDAExt/cublaslt.jl
@@ -1,36 +1,30 @@
 const TransOrAdjOrRegStridedCuMatrix{T} = Union{Transpose{T, <:StridedCuMatrix{T}},
     Adjoint{T, <:StridedCuMatrix{T}}, StridedCuMatrix{T}}
 
-function LuxLib._cublaslt_matmul_fused!(@nospecialize(y::TransOrAdjOrRegStridedCuMatrix),
-        σ::F, @nospecialize(w::TransOrAdjOrRegStridedCuMatrix),
-        @nospecialize(x::TransOrAdjOrRegStridedCuMatrix),
-        b::Union{Nothing, StridedCuVector},
-        aux::Union{Nothing, TransOrAdjOrRegStridedCuMatrix}=nothing) where {F}
+function LuxLib._cublaslt_matmul_fused!(
+        @nospecialize(y::TransOrAdjOrRegStridedCuMatrix{<:Real}),
+        σ::F, @nospecialize(w::TransOrAdjOrRegStridedCuMatrix{<:Real}),
+        @nospecialize(x::TransOrAdjOrRegStridedCuMatrix{<:Real}),
+        b::Union{Nothing, StridedCuVector{<:Real}},
+        aux::Union{Nothing, StridedCuMatrix{<:Real}}=nothing) where {F}
     transy = y isa Transpose || y isa Adjoint
     transx = x isa Transpose || x isa Adjoint
-    transw = w isa Transpose || w isa Adjoint
-    if aux !== nothing
-        transaux = aux isa Transpose || aux isa Adjoint
-        aux_ = parent(aux)
-    else
-        transaux = false
-        aux_ = nothing
-    end
+    transw = w isa Transpose || x isa Adjoint
     return LuxLib._cublaslt_matmul_fused!(
-        transy, parent(y), σ, transw, parent(w), transx, parent(x), b, transaux, aux_)
+        transy, parent(y), σ, transw, parent(w), transx, parent(x), b, aux)
 end
 
 function LuxLib._cublaslt_matmul_fused!(
         transy::Bool, @nospecialize(y::StridedCuMatrix{yT}), σ::F,
         transw::Bool, @nospecialize(w::StridedCuMatrix{wT}), transx::Bool,
         @nospecialize(x::StridedCuMatrix{xT}), b::Union{Nothing, StridedCuVector},
-        transaux::Bool, aux::Union{Nothing, StridedCuMatrix}) where {F, yT, wT, xT}
+        aux::Union{Nothing, StridedCuMatrix}) where {F, yT, wT, xT}
     wxT = promote_type(wT, xT)
     @warn "Mixed Precision Inputs received for `weight`: $(typeof(w)) and `x`: \
            $(typeof(x)). Promoting to $(wxT)." maxlog=1
     return LuxLib._cublaslt_matmul_fused!(
         transy, y, σ, transw, LuxLib._oftype_array(wxT, w),
-        transx, LuxLib._oftype_array(wxT, x), b, transaux, aux)
+        transx, LuxLib._oftype_array(wxT, x), b, aux)
 end
 
 # TODO: use https://docs.nvidia.com/cuda/cublas/#cublasltmatmul for a more robust
@@ -42,7 +36,7 @@ function LuxLib._cublaslt_matmul_fused!(
         transy::Bool, @nospecialize(y::StridedCuMatrix{yT}), σ::F,
         transw::Bool, @nospecialize(w::StridedCuMatrix{wxT}), transx::Bool,
         @nospecialize(x::StridedCuMatrix{wxT}), b::Union{Nothing, StridedCuVector},
-        transaux::Bool, aux::Union{Nothing, StridedCuMatrix}) where {F, yT, wxT}
+        aux::Union{Nothing, StridedCuMatrix}) where {F, yT, wxT}
     m = size(y, 1)
     n = size(y, 2)
     k = size(w, 2)
@@ -82,7 +76,7 @@ function LuxLib._cublaslt_matmul_fused!(
         Ref{CUBLAS.cublasOperation_t}(ytransop), sizeof(ytransop))
 
     # Decide on the epilogue
-    epilogue, activation_fused = __epilogue_act(σ, b)
+    epilogue, activation_fused = __epilogue_act(σ, b, aux)
     CUBLAS.cublasLtMatmulDescSetAttribute(
         operationDesc[], CUBLAS.CUBLASLT_MATMUL_DESC_EPILOGUE,
         Ref{CUBLAS.cublasLtEpilogue_t}(epilogue), sizeof(epilogue))
@@ -93,6 +87,17 @@ function LuxLib._cublaslt_matmul_fused!(
         CUBLAS.cublasLtMatmulDescSetAttribute(
             operationDesc[], CUBLAS.CUBLASLT_MATMUL_DESC_BIAS_POINTER,
             bias_ptr, sizeof(bias_ptr))
+    end
+
+    if aux !== nothing
+        aux_ptr = Ref{CuPtr{Cvoid}}(pointer(aux))
+        CUBLAS.cublasLtMatmulDescSetAttribute(
+            operationDesc[], CUBLAS.CUBLASLT_MATMUL_DESC_EPILOGUE_AUX_POINTER,
+            aux_ptr, sizeof(aux_ptr))
+        ldaux = max(1, stride(aux, 2))
+        CUBLAS.cublasLtMatmulDescSetAttribute(
+            operationDesc[], CUBLAS.CUBLASLT_MATMUL_DESC_EPILOGUE_AUX_LD,
+            Ref{Csize_t}(ldaux), sizeof(ldaux))
     end
 
     # Create the matrix layouts
@@ -133,18 +138,47 @@ function LuxLib._cublaslt_matmul_fused!(
     return 0
 end
 
-@inline __epilogue_act(::typeof(identity), ::Nothing) = (
-    CUBLAS.CUBLASLT_EPILOGUE_DEFAULT, true)
-@inline __epilogue_act(::typeof(identity), ::StridedCuVector) = (
-    CUBLAS.CUBLASLT_EPILOGUE_BIAS, true)
-@inline __epilogue_act(::typeof(NNlib.relu), ::Nothing) = (
-    CUBLAS.CUBLASLT_EPILOGUE_RELU, true)
-@inline __epilogue_act(::typeof(NNlib.relu), ::StridedCuVector) = (
-    CUBLAS.CUBLASLT_EPILOGUE_RELU_BIAS, true)
-@inline __epilogue_act(::typeof(NNlib.gelu), ::Nothing) = (
-    CUBLAS.CUBLASLT_EPILOGUE_GELU, true)
-@inline __epilogue_act(::typeof(NNlib.gelu), ::StridedCuVector) = (
-    CUBLAS.CUBLASLT_EPILOGUE_GELU_BIAS, true)
-@inline __epilogue_act(::F, ::Nothing) where {F} = (CUBLAS.CUBLASLT_EPILOGUE_DEFAULT, false)
-@inline __epilogue_act(::F, ::StridedCuVector) where {F} = (
-    CUBLAS.CUBLASLT_EPILOGUE_BIAS, false)
+@inline function __epilogue_act(f::F, b, aux) where {F}
+    if f === identity
+        @assert aux===nothing "`aux` must be `nothing` for `identity` activation."
+        if b === nothing
+            return CUBLAS.CUBLASLT_EPILOGUE_DEFAULT, true
+        else
+            return CUBLAS.CUBLASLT_EPILOGUE_BIAS, true
+        end
+    elseif f === NNlib.relu
+        if b === nothing
+            if aux === nothing
+                return CUBLAS.CUBLASLT_EPILOGUE_RELU, true
+            else
+                return CUBLAS.CUBLASLT_EPILOGUE_RELU_AUX, true
+            end
+        else
+            if aux === nothing
+                return CUBLAS.CUBLASLT_EPILOGUE_RELU_BIAS, true
+            else
+                return CUBLAS.CUBLASLT_EPILOGUE_RELU_AUX_BIAS, true
+            end
+        end
+    elseif f === NNlib.gelu
+        if b === nothing
+            if aux === nothing
+                return CUBLAS.CUBLASLT_EPILOGUE_GELU, true
+            else
+                return CUBLAS.CUBLASLT_EPILOGUE_GELU_AUX, true
+            end
+        else
+            if aux === nothing
+                return CUBLAS.CUBLASLT_EPILOGUE_GELU_BIAS, true
+            else
+                return CUBLAS.CUBLASLT_EPILOGUE_GELU_AUX_BIAS, true
+            end
+        end
+    else
+        if b === nothing
+            return CUBLAS.CUBLASLT_EPILOGUE_DEFAULT, false
+        else
+            return CUBLAS.CUBLASLT_EPILOGUE_BIAS, false
+        end
+    end
+end

--- a/ext/LuxLibCUDAExt/fused_dense.jl
+++ b/ext/LuxLibCUDAExt/fused_dense.jl
@@ -34,10 +34,39 @@ end
 end
 
 ## Special Reverse Pass for gelu activation. All other cases, we don't need special handling
-
-function CRC.rrule(cfg::CRC.RuleConfig{>:CRC.HasReverseMode},
+function CRC.rrule(::CRC.RuleConfig{>:CRC.HasReverseMode},
         ::typeof(LuxLib.__fused_dense_bias_activation_impl), ::typeof(NNlib.gelu),
         weight::CUDA.AnyCuMatrix, x::CUDA.AnyCuMatrix, b::Union{CUDA.AnyCuVector, Nothing})
-    error("Not Implemented")
-    return
+    z = similar(x, LuxLib.__get_concrete_fba_output_eltype(NNlib.gelu, weight, x, b),
+        size(weight, 1), size(x, 2))
+    y = z # aliased for now for type stability
+    retcode = -1
+    if hasmethod(LuxLib._cublaslt_matmul_fused!,
+        (typeof(z), typeof(NNlib.gelu), typeof(weight), typeof(x), typeof(b)))
+        y = similar(z)  # break aliasing
+        retcode = LuxLib._cublaslt_matmul_fused!(z, NNlib.gelu, weight, x, b, y)
+        if retcode == -1
+            @warn "cuBLASLt failed for the given inputs $(NNlib.gelu), $(typeof(weight)) \
+                [$(size(weight))], $(typeof(x)) [$(size(x))], $(typeof(b)) \
+                [$(__length(b))]. Falling back to generic implementation." maxlog=1
+        end
+    else
+        @warn "cuBLASLt not available. Falling back to generic implementation." maxlog=1
+    end
+
+    if retcode == -1
+        # Generic Fallback: break aliasing in _apply_bias_activation!!
+        mul!(z, weight, x)
+        z, y = LuxLib.__apply_bias_activation!!(NNlib.gelu, z, b, Val(true))
+    end
+
+    ∇__fused_dense_bias_activation_impl_cublaslt = @closure Δ -> begin
+        ∂y = LuxLib.__activation_gradient(CRC.unthunk(Δ), z, NNlib.gelu, y)
+        ∂b = LuxLib.__added_bias_gradient(b, ∂y)
+        ∂x = weight' * ∂y
+        ∂w = ∂y * x'
+        return CRC.NoTangent(), CRC.NoTangent(), ∂w, ∂x, ∂b
+    end
+
+    return z, ∇__fused_dense_bias_activation_impl_cublaslt
 end

--- a/ext/LuxLibCUDAExt/fused_dense.jl
+++ b/ext/LuxLibCUDAExt/fused_dense.jl
@@ -1,0 +1,34 @@
+@inline __length(x) = length(x)
+@inline __length(::Nothing) = nothing
+
+function LuxLib.__fused_dense_bias_activation_impl(
+        act::F, weight::CUDA.AnyCuMatrix, x::CUDA.AnyCuMatrix,
+        b::Union{Nothing, CUDA.AnyCuVector}) where {F}
+    y = similar(x, LuxLib.__get_concrete_fba_output_eltype(act, weight, x, b),
+        size(weight, 1), size(x, 2))
+    if hasmethod(LuxLib._cublaslt_matmul_fused!,
+        (typeof(y), F, typeof(weight), typeof(x), typeof(b)))
+        retcode = LuxLib._cublaslt_matmul_fused!(y, act, weight, x, b)
+        retcode == 0 && return y
+        # cuBLASLt failed for the given inputs use the generic fallback
+        @warn "cuBLASLt failed for the given inputs $(act), $(typeof(weight)) \
+               [$(size(weight))], $(typeof(x)) [$(size(x))], $(typeof(b)) \
+               [$(__length(b))]. Falling back to generic implementation." maxlog=1
+    else
+        @warn "cuBLASLt not available. Falling back to generic implementation." maxlog=1
+    end
+    mul!(y, weight, x)
+    return LuxLib.__apply_bias_activation!!(act, y, b, Val(false))
+end
+
+## Hijack mixed precision on CUDA to use cuBLASLt if possible
+@inline function LuxLib.fused_dense_bias_activation(
+        σ::F, weight::CUDA.AnyCuMatrix{wT}, x::CUDA.AnyCuMatrix{xT},
+        b::CUDA.AnyCuVector{bT}) where {F, wT, xT, bT}
+    return LuxLib.__fused_dense_bias_activation_impl(σ, weight, x, b)
+end
+
+@inline function LuxLib.fused_dense_bias_activation(σ::F, weight::CUDA.AnyCuMatrix{wT},
+        x::CUDA.AnyCuMatrix{xT}, b::Nothing) where {F, wT, xT}
+    return LuxLib.__fused_dense_bias_activation_impl(σ, weight, x, b)
+end

--- a/ext/LuxLibCUDAExt/fused_dense.jl
+++ b/ext/LuxLibCUDAExt/fused_dense.jl
@@ -32,3 +32,12 @@ end
         x::CUDA.AnyCuMatrix{xT}, b::Nothing) where {F, wT, xT}
     return LuxLib.__fused_dense_bias_activation_impl(σ, weight, x, b)
 end
+
+## Special Reverse Pass for gelu activation. All other cases, we don't need special handling
+
+function CRC.rrule(cfg::CRC.RuleConfig{>:CRC.HasReverseMode},
+        ::typeof(LuxLib.__fused_dense_bias_activation_impl), ::typeof(NNlib.gelu),
+        weight::CUDA.AnyCuMatrix, x::CUDA.AnyCuMatrix, b::Union{CUDA.AnyCuVector, Nothing})
+    error("Not Implemented")
+    return
+end

--- a/ext/LuxLibCUDAExt/fused_dense.jl
+++ b/ext/LuxLibCUDAExt/fused_dense.jl
@@ -35,18 +35,19 @@ end
 
 ## Special Reverse Pass for gelu activation. All other cases, we don't need special handling
 function CRC.rrule(::CRC.RuleConfig{>:CRC.HasReverseMode},
-        ::typeof(LuxLib.__fused_dense_bias_activation_impl), ::typeof(NNlib.gelu),
-        weight::CUDA.AnyCuMatrix, x::CUDA.AnyCuMatrix, b::Union{CUDA.AnyCuVector, Nothing})
+        ::typeof(LuxLib.__fused_dense_bias_activation_impl),
+        act::typeof(NNlib.gelu), weight::CUDA.AnyCuMatrix,
+        x::CUDA.AnyCuMatrix, b::Union{CUDA.AnyCuVector, Nothing})
     z = similar(x, LuxLib.__get_concrete_fba_output_eltype(NNlib.gelu, weight, x, b),
         size(weight, 1), size(x, 2))
     y = z # aliased for now for type stability
     retcode = -1
     if hasmethod(LuxLib._cublaslt_matmul_fused!,
-        (typeof(z), typeof(NNlib.gelu), typeof(weight), typeof(x), typeof(b)))
+        (typeof(z), typeof(act), typeof(weight), typeof(x), typeof(b)))
         y = similar(z)  # break aliasing
-        retcode = LuxLib._cublaslt_matmul_fused!(z, NNlib.gelu, weight, x, b, y)
+        retcode = LuxLib._cublaslt_matmul_fused!(z, act, weight, x, b, y)
         if retcode == -1
-            @warn "cuBLASLt failed for the given inputs $(NNlib.gelu), $(typeof(weight)) \
+            @warn "cuBLASLt failed for the given inputs $(act), $(typeof(weight)) \
                 [$(size(weight))], $(typeof(x)) [$(size(x))], $(typeof(b)) \
                 [$(__length(b))]. Falling back to generic implementation." maxlog=1
         end
@@ -57,11 +58,11 @@ function CRC.rrule(::CRC.RuleConfig{>:CRC.HasReverseMode},
     if retcode == -1
         # Generic Fallback: break aliasing in _apply_bias_activation!!
         mul!(z, weight, x)
-        z, y = LuxLib.__apply_bias_activation!!(NNlib.gelu, z, b, Val(true))
+        z, y = LuxLib.__apply_bias_activation!!(act, z, b, Val(true))
     end
 
     ∇__fused_dense_bias_activation_impl_cublaslt = @closure Δ -> begin
-        ∂y = LuxLib.__activation_gradient(CRC.unthunk(Δ), z, NNlib.gelu, y)
+        ∂y = LuxLib.__activation_gradient(CRC.unthunk(Δ), z, act, y)
         ∂b = LuxLib.__added_bias_gradient(b, ∂y)
         ∂x = weight' * ∂y
         ∂w = ∂y * x'

--- a/ext/LuxLibForwardDiffExt.jl
+++ b/ext/LuxLibForwardDiffExt.jl
@@ -1,9 +1,11 @@
 module LuxLibForwardDiffExt
 
 using ForwardDiff: ForwardDiff
-using GPUArraysCore: AnyGPUArray
 using LuxLib: LuxLib
-using NNlib: NNlib, ConvDims
+using NNlib: NNlib
+
+LuxLib.__has_dual(::ForwardDiff.Dual) = true
+LuxLib.__has_dual(::AbstractArray{<:ForwardDiff.Dual}) = true
 
 # dropout
 @inline function LuxLib._dropout_fptype(x::AbstractArray{<:ForwardDiff.Dual})
@@ -15,16 +17,16 @@ end
 #       and cut down substantially on the time to compute jacobians.
 # Here we should be broadcasting with `Tag` for safety but that breaks GPU compilation.
 for op in [:conv, :depthwiseconv, :∇conv_data, :∇conv_filter]
-    op! = Symbol("$(op)!")
+    luxlibop = Symbol("__$(op)")
 
     @eval function NNlib.$(op)(x1::AbstractArray{<:ForwardDiff.Dual{Tag, V, P}, N},
             x2::AbstractArray{<:Real, N}, cdims::NNlib.ConvDims;
             kwargs...) where {N, Tag, V, P}
         x1_data = ForwardDiff.value.(x1)
 
-        y = NNlib.$(op)(x1_data, x2, cdims; kwargs...)
+        y = LuxLib.$(luxlibop)(x1_data, x2, cdims; kwargs...)
         dys = ntuple(
-            i -> NNlib.$(op)(ForwardDiff.partials.(x1, i), x2, cdims; kwargs...), P)
+            i -> LuxLib.$(luxlibop)(ForwardDiff.partials.(x1, i), x2, cdims; kwargs...), P)
 
         return map(
             (yᵢ, dyᵢ...) -> ForwardDiff.Dual{Tag, V, P}(yᵢ, ForwardDiff.Partials(dyᵢ)),
@@ -36,9 +38,9 @@ for op in [:conv, :depthwiseconv, :∇conv_data, :∇conv_filter]
             cdims::NNlib.ConvDims; kwargs...) where {N, Tag, V, P}
         x2_data = ForwardDiff.value.(x2)
 
-        y = NNlib.$(op)(x1, x2_data, cdims; kwargs...)
+        y = LuxLib.$(luxlibop)(x1, x2_data, cdims; kwargs...)
         dys = ntuple(
-            i -> NNlib.$(op)(x1, ForwardDiff.partials.(x2, i), cdims; kwargs...), P)
+            i -> LuxLib.$(luxlibop)(x1, ForwardDiff.partials.(x2, i), cdims; kwargs...), P)
 
         return map(
             (yᵢ, dyᵢ...) -> ForwardDiff.Dual{Tag, V, P}(yᵢ, ForwardDiff.Partials(dyᵢ)),
@@ -51,11 +53,13 @@ for op in [:conv, :depthwiseconv, :∇conv_data, :∇conv_filter]
         x1_data = ForwardDiff.value.(x1)
         x2_data = ForwardDiff.value.(x2)
 
-        y = NNlib.$(op)(x1_data, x2_data, cdims; kwargs...)
+        y = LuxLib.$(luxlibop)(x1_data, x2_data, cdims; kwargs...)
 
         dys₁ = ntuple(P) do i
-            dys₁ᵢ = NNlib.$(op)(ForwardDiff.partials.(x1, i), x2_data, cdims; kwargs...)
-            dys₂ᵢ = NNlib.$(op)(x1_data, ForwardDiff.partials.(x2, i), cdims; kwargs...)
+            dys₁ᵢ = LuxLib.$(luxlibop)(
+                ForwardDiff.partials.(x1, i), x2_data, cdims; kwargs...)
+            dys₂ᵢ = LuxLib.$(luxlibop)(
+                x1_data, ForwardDiff.partials.(x2, i), cdims; kwargs...)
             dys₁ᵢ .+= dys₂ᵢ
             return dys₁ᵢ
         end
@@ -68,53 +72,21 @@ for op in [:conv, :depthwiseconv, :∇conv_data, :∇conv_filter]
     end
 end
 
-# TODO: We would want to use the fused versions here, but for now we will just dispatch the
-#       duals to the generic implementation for GPUArrays
-function LuxLib.fused_conv_bias_activation(σ::F, weight::AnyGPUArray{<:ForwardDiff.Dual, N},
-        x::AnyGPUArray{xT, N}, bias::Nothing, cdims::ConvDims) where {F, N, xT}
-    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
+# Don't try to promote the input types
+@inline function LuxLib.__gpu_get_weight_input(
+        ::Type{T}, ::Type{<:ForwardDiff.Dual}, weight, x) where {T}
+    return LuxLib.__materialize_subarray(weight), LuxLib.__materialize_subarray(x)
 end
-function LuxLib.fused_conv_bias_activation(
-        σ::F, weight::AnyGPUArray{wT, N}, x::AnyGPUArray{<:ForwardDiff.Dual, N},
-        bias::Nothing, cdims::ConvDims) where {F, N, wT}
-    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
+@inline function LuxLib.__gpu_get_weight_input(
+        ::Type{<:ForwardDiff.Dual}, ::Type{T}, weight, x) where {T}
+    return LuxLib.__materialize_subarray(weight), LuxLib.__materialize_subarray(x)
 end
-function LuxLib.fused_conv_bias_activation(σ::F, weight::AnyGPUArray{<:ForwardDiff.Dual, N},
-        x::AnyGPUArray{<:ForwardDiff.Dual, N}, bias::Nothing, cdims::ConvDims) where {F, N}
-    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
-end
-function LuxLib.fused_conv_bias_activation(
-        σ::F, weight::AnyGPUArray{<:ForwardDiff.Dual, N}, x::AnyGPUArray{xT, N},
-        bias::AnyGPUArray{bT, N}, cdims::ConvDims) where {F, N, xT, bT}
-    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
-end
-function LuxLib.fused_conv_bias_activation(
-        σ::F, weight::AnyGPUArray{wT, N}, x::AnyGPUArray{<:ForwardDiff.Dual, N},
-        bias::AnyGPUArray{bT, N}, cdims::ConvDims) where {F, wT, bT, N}
-    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
-end
-function LuxLib.fused_conv_bias_activation(σ::F, weight::AnyGPUArray{<:ForwardDiff.Dual, N},
-        x::AnyGPUArray{<:ForwardDiff.Dual, N},
-        bias::AnyGPUArray{bT, N}, cdims::ConvDims) where {F, N, bT}
-    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
-end
-function LuxLib.fused_conv_bias_activation(
-        σ::F, weight::AnyGPUArray{<:ForwardDiff.Dual, N}, x::AnyGPUArray{xT, N},
-        bias::AnyGPUArray{<:ForwardDiff.Dual, N}, cdims::ConvDims) where {F, N, xT}
-    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
-end
-function LuxLib.fused_conv_bias_activation(
-        σ::F, weight::AnyGPUArray{wT, N}, x::AnyGPUArray{<:ForwardDiff.Dual, N},
-        bias::AnyGPUArray{<:ForwardDiff.Dual, N}, cdims::ConvDims) where {F, N, wT}
-    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
-end
-function LuxLib.fused_conv_bias_activation(σ::F, weight::AnyGPUArray{<:ForwardDiff.Dual, N},
-        x::AnyGPUArray{<:ForwardDiff.Dual, N},
-        bias::AnyGPUArray{<:ForwardDiff.Dual, N}, cdims::ConvDims) where {F, N}
-    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
+@inline function LuxLib.__gpu_get_weight_input(
+        ::Type{<:ForwardDiff.Dual}, ::Type{<:ForwardDiff.Dual}, weight, x)
+    return LuxLib.__materialize_subarray(weight), LuxLib.__materialize_subarray(x)
 end
 
-function LuxLib._drop_forwarddiff_partials(x::AbstractArray{<:ForwardDiff.Dual})
+@inline function LuxLib._drop_forwarddiff_partials(x::AbstractArray{<:ForwardDiff.Dual})
     return ForwardDiff.value.(x)
 end
 

--- a/ext/LuxLibForwardDiffExt.jl
+++ b/ext/LuxLibForwardDiffExt.jl
@@ -1,8 +1,9 @@
 module LuxLibForwardDiffExt
 
 using ForwardDiff: ForwardDiff
+using GPUArraysCore: AnyGPUArray
 using LuxLib: LuxLib
-using NNlib: NNlib
+using NNlib: NNlib, ConvDims
 
 # dropout
 @inline function LuxLib._dropout_fptype(x::AbstractArray{<:ForwardDiff.Dual})
@@ -65,6 +66,52 @@ for op in [:conv, :depthwiseconv, :∇conv_data, :∇conv_filter]
             (yᵢ, dyᵢ...) -> ForwardDiff.Dual{Tag, Vₓ, P}(yᵢ, ForwardDiff.Partials(dyᵢ)),
             y, dys₁...)
     end
+end
+
+# TODO: We would want to use the fused versions here, but for now we will just dispatch the
+#       duals to the generic implementation for GPUArrays
+function LuxLib.fused_conv_bias_activation(σ::F, weight::AnyGPUArray{<:ForwardDiff.Dual, N},
+        x::AnyGPUArray{xT, N}, bias::Nothing, cdims::ConvDims) where {F, N, xT}
+    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
+end
+function LuxLib.fused_conv_bias_activation(
+        σ::F, weight::AnyGPUArray{wT, N}, x::AnyGPUArray{<:ForwardDiff.Dual, N},
+        bias::Nothing, cdims::ConvDims) where {F, N, wT}
+    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
+end
+function LuxLib.fused_conv_bias_activation(σ::F, weight::AnyGPUArray{<:ForwardDiff.Dual, N},
+        x::AnyGPUArray{<:ForwardDiff.Dual, N}, bias::Nothing, cdims::ConvDims) where {F, N}
+    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
+end
+function LuxLib.fused_conv_bias_activation(
+        σ::F, weight::AnyGPUArray{<:ForwardDiff.Dual, N}, x::AnyGPUArray{xT, N},
+        bias::AnyGPUArray{bT, N}, cdims::ConvDims) where {F, N, xT, bT}
+    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
+end
+function LuxLib.fused_conv_bias_activation(
+        σ::F, weight::AnyGPUArray{wT, N}, x::AnyGPUArray{<:ForwardDiff.Dual, N},
+        bias::AnyGPUArray{bT, N}, cdims::ConvDims) where {F, wT, bT, N}
+    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
+end
+function LuxLib.fused_conv_bias_activation(σ::F, weight::AnyGPUArray{<:ForwardDiff.Dual, N},
+        x::AnyGPUArray{<:ForwardDiff.Dual, N},
+        bias::AnyGPUArray{bT, N}, cdims::ConvDims) where {F, N, bT}
+    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
+end
+function LuxLib.fused_conv_bias_activation(
+        σ::F, weight::AnyGPUArray{<:ForwardDiff.Dual, N}, x::AnyGPUArray{xT, N},
+        bias::AnyGPUArray{<:ForwardDiff.Dual, N}, cdims::ConvDims) where {F, N, xT}
+    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
+end
+function LuxLib.fused_conv_bias_activation(
+        σ::F, weight::AnyGPUArray{wT, N}, x::AnyGPUArray{<:ForwardDiff.Dual, N},
+        bias::AnyGPUArray{<:ForwardDiff.Dual, N}, cdims::ConvDims) where {F, N, wT}
+    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
+end
+function LuxLib.fused_conv_bias_activation(σ::F, weight::AnyGPUArray{<:ForwardDiff.Dual, N},
+        x::AnyGPUArray{<:ForwardDiff.Dual, N},
+        bias::AnyGPUArray{<:ForwardDiff.Dual, N}, cdims::ConvDims) where {F, N}
+    return LuxLib._generic_conv_bias_activation(σ, weight, x, bias, cdims)
 end
 
 function LuxLib._drop_forwarddiff_partials(x::AbstractArray{<:ForwardDiff.Dual})

--- a/src/LuxLib.jl
+++ b/src/LuxLib.jl
@@ -7,7 +7,7 @@ using PrecompileTools: @recompile_invalidations
     using ChainRulesCore: ChainRulesCore
     using FastBroadcast: @..
     using FastClosures: @closure
-    using GPUArraysCore: GPUArraysCore
+    using GPUArraysCore: GPUArraysCore, AnyGPUArray
     using KernelAbstractions: KernelAbstractions, @Const, @index, @kernel
     using LinearAlgebra: LinearAlgebra, BLAS, mul!
     using LuxCore: LuxCore

--- a/src/api/conv.jl
+++ b/src/api/conv.jl
@@ -21,34 +21,26 @@ reallocations by reusing the output buffer for multiple operations.
     `relu`. For other activations, it tries to fuse the operations on the Julia side.
   - If any of the inputs, don't support setindexing (aka immutable arrays) we fallback to
     the generic non-mutating implementation.
-  - For mixed precision inputs, we use the fallback allocating implementation.
   - Maximum memory reuse and operation fusion is guaranteed for ChainRules compatible AD
     backends or backends that support mutation. Backends like `Tracker` and `ReverseDiff`
     fallback to the generic implementation.
   - For Mixed-Precision Inputs on GPU, we type promote the inputs to the highest precision,
     with a warning.
 """
-function fused_conv_bias_activation end
+@inline function fused_conv_bias_activation(
+        σ::F, weight::AbstractArray{<:Number, N}, x::AbstractArray{<:Number, N},
+        b::AbstractArray{<:Number, N}, cdims::ConvDims) where {F, N}
+    return fused_conv_bias_activation(
+        σ, weight, __is_immutable_array_or_dual_val(weight), x,
+        __is_immutable_array_or_dual_val(x), b, __is_immutable_array_or_dual_val(b), cdims)
+end
 
-# Avoid Ambiguity
-for aType in (AbstractArray, GPUArraysCore.AnyGPUArray)
-    @eval begin
-        @inline function fused_conv_bias_activation(
-                σ::F, weight::$(aType){T, N}, x::$(aType){T, N},
-                b::$(aType){T, N}, cdims::ConvDims) where {F, T, N}
-            return fused_conv_bias_activation(
-                σ, weight, __is_immutable_array_val(weight), x,
-                __is_immutable_array_val(x), b, __is_immutable_array_val(b), cdims)
-        end
-
-        @inline function fused_conv_bias_activation(
-                σ::F, weight::$(aType){T, N}, x::$(aType){T, N},
-                b::Nothing, cdims::ConvDims) where {F, T, N}
-            return fused_conv_bias_activation(
-                σ, weight, __is_immutable_array_val(weight), x,
-                __is_immutable_array_val(x), b, __is_immutable_array_val(b), cdims)
-        end
-    end
+@inline function fused_conv_bias_activation(
+        σ::F, weight::AbstractArray{<:Number, N}, x::AbstractArray{<:Number, N},
+        b::Nothing, cdims::ConvDims) where {F, N}
+    return fused_conv_bias_activation(
+        σ, weight, __is_immutable_array_or_dual_val(weight), x,
+        __is_immutable_array_or_dual_val(x), b, __is_immutable_array_or_dual_val(b), cdims)
 end
 
 @inline function fused_conv_bias_activation(
@@ -61,52 +53,4 @@ end
         σ::F, weight::AbstractArray, ::Val, x::AbstractArray, ::Val,
         b::Union{Nothing, AbstractArray}, ::Val, cdims::ConvDims) where {F}
     return _generic_conv_bias_activation(σ, weight, x, b, cdims)
-end
-
-# SubArray Inputs: copy a subarray to make it contiguous in memory
-@inline function fused_conv_bias_activation(
-        σ::F, weight::AbstractArray{wT, N}, x::SubArray{xT, N},
-        b::AbstractArray{bT, N}, cdims::ConvDims) where {F, wT, xT, bT, N}
-    return fused_conv_bias_activation(σ, weight, copy(x), b, cdims)
-end
-
-@inline function fused_conv_bias_activation(
-        σ::F, weight::AbstractArray{wT, N}, x::SubArray{xT, N},
-        b::Nothing, cdims::ConvDims) where {F, wT, xT, N}
-    return fused_conv_bias_activation(σ, weight, copy(x), b, cdims)
-end
-
-# Mixed Precision Generic (Non GPU) Inputs: Code in NNlib can handle this case, but not for
-# the GPU case
-@inline function fused_conv_bias_activation(
-        σ::F, weight::AbstractArray{wT, N}, x::AbstractArray{xT, N},
-        b::AbstractArray{bT, N}, cdims::ConvDims) where {F, wT, xT, bT, N}
-    return _generic_conv_bias_activation(σ, weight, x, b, cdims)
-end
-
-@inline function fused_conv_bias_activation(
-        σ::F, weight::AbstractArray{wT, N}, x::AbstractArray{xT, N},
-        b::Nothing, cdims::ConvDims) where {F, wT, xT, N}
-    return _generic_conv_bias_activation(σ, weight, x, b, cdims)
-end
-
-# Mixed Precision GPU Inputs
-@inline function fused_conv_bias_activation(
-        σ::F, weight::GPUArraysCore.AnyGPUArray{wT, N}, x::GPUArraysCore.AnyGPUArray{xT, N},
-        b::GPUArraysCore.AnyGPUArray{bT, N}, cdims::ConvDims) where {F, wT, xT, bT, N}
-    T = __get_concrete_fba_output_eltype(σ, weight, x, b)
-    @warn "Mixed Precision Inputs on GPU for `fused_conv_bias_activation`. Promoting \
-           computation to $T" weight=wT x=xT bias=bT maxlog=1
-    return fused_conv_bias_activation(
-        σ, _oftype_array(T, weight), _oftype_array(T, x), _oftype_array(T, b), cdims)
-end
-
-@inline function fused_conv_bias_activation(
-        σ::F, weight::GPUArraysCore.AnyGPUArray{wT, N}, x::GPUArraysCore.AnyGPUArray{xT, N},
-        b::Nothing, cdims::ConvDims) where {F, wT, xT, N}
-    T = __get_concrete_fba_output_eltype(σ, weight, x, b)
-    @warn "Mixed Precision Inputs on GPU for `fused_conv_bias_activation`. Promoting \
-           computation to $T" weight=wT x=xT maxlog=1
-    return fused_conv_bias_activation(
-        σ, _oftype_array(T, weight), _oftype_array(T, x), b, cdims)
 end

--- a/src/api/dense.jl
+++ b/src/api/dense.jl
@@ -21,23 +21,23 @@ multiple operations.
     though this function doesn't call those operations.
   - If any of the inputs, don't support setindexing (aka immutable arrays) we fallback to
     the generic non-mutating implementation.
-  - For mixed precision inputs, we use the fallback allocating implementation.
   - Maximum memory reuse and operation fusion is guaranteed for ChainRules compatible AD
     backends or backends that support mutation. Backends like `Tracker` and `ReverseDiff`
     fallback to the generic implementation.
   - For CUDA Arrays, this uses a special fused implementation via cuBLASLt.
 """
 @inline function fused_dense_bias_activation(
-        σ::F, weight::AbstractMatrix{T}, x::AbstractMatrix{T}, b::Nothing) where {F, T}
-    return fused_dense_bias_activation(σ, weight, __is_immutable_array_val(weight), x,
-        __is_immutable_array_val(x), b, __is_immutable_array_val(b))
+        σ::F, weight::AbstractMatrix, x::AbstractMatrix, b::Nothing) where {F}
+    return fused_dense_bias_activation(
+        σ, weight, __is_immutable_array_or_dual_val(weight), x,
+        __is_immutable_array_or_dual_val(x), b, __is_immutable_array_or_dual_val(b))
 end
 
 @inline function fused_dense_bias_activation(
-        σ::F, weight::AbstractMatrix{T}, x::AbstractMatrix{T},
-        b::AbstractVector{T}) where {F, T}
-    return fused_dense_bias_activation(σ, weight, __is_immutable_array_val(weight), x,
-        __is_immutable_array_val(x), b, __is_immutable_array_val(b))
+        σ::F, weight::AbstractMatrix, x::AbstractMatrix, b::AbstractVector) where {F}
+    return fused_dense_bias_activation(
+        σ, weight, __is_immutable_array_or_dual_val(weight), x,
+        __is_immutable_array_or_dual_val(x), b, __is_immutable_array_or_dual_val(b))
 end
 
 @inline function fused_dense_bias_activation(
@@ -49,17 +49,5 @@ end
 @inline function fused_dense_bias_activation(
         σ::F, weight::AbstractMatrix, ::Val, x::AbstractMatrix,
         ::Val, b::Union{Nothing, AbstractVector}, ::Val) where {F}
-    return __generic_dense_bias_activation(σ, weight, x, b)
-end
-
-# Mixed Precision Casex
-@inline function fused_dense_bias_activation(
-        σ::F, weight::AbstractMatrix{wT}, x::AbstractMatrix{xT},
-        b::AbstractVector{bT}) where {F, wT, xT, bT}
-    return __generic_dense_bias_activation(σ, weight, x, b)
-end
-
-@inline function fused_dense_bias_activation(σ::F, weight::AbstractMatrix{wT},
-        x::AbstractMatrix{xT}, b::Nothing) where {F, wT, xT}
     return __generic_dense_bias_activation(σ, weight, x, b)
 end

--- a/src/api/dense.jl
+++ b/src/api/dense.jl
@@ -17,7 +17,6 @@ multiple operations.
 ## Notes on implementation
 
   - Despite the naming, currently only the activation (σ) is fused with the bias addition.
-    We are working towards using faster hardware specific fused kernels for this operation.
     Currently this is equivalent to using matrix multiply followed by `NNlib.bias_act!`,
     though this function doesn't call those operations.
   - If any of the inputs, don't support setindexing (aka immutable arrays) we fallback to
@@ -26,6 +25,7 @@ multiple operations.
   - Maximum memory reuse and operation fusion is guaranteed for ChainRules compatible AD
     backends or backends that support mutation. Backends like `Tracker` and `ReverseDiff`
     fallback to the generic implementation.
+  - For CUDA Arrays, this uses a special fused implementation via cuBLASLt.
 """
 @inline function fused_dense_bias_activation(
         σ::F, weight::AbstractMatrix{T}, x::AbstractMatrix{T}, b::Nothing) where {F, T}

--- a/src/impl/fused_dense.jl
+++ b/src/impl/fused_dense.jl
@@ -4,14 +4,8 @@ function __generic_dense_bias_activation(act::F, weight::AbstractMatrix, x::Abst
 end
 
 # Why are we catching the implementation at this point and not in `bias_act!` like NNlib?
-# Turns out NVIDIA has been shipping a bunch of fused kernels for a while now. We can
-# potentially use those here to fuse all the operations into a single kernel.
-#
-# Currently that is not implemented, but once implemented integrating them into Lux will be
-# trivial.
-#
-# Alternatively we have a native julia version in https://github.com/JuliaGPU/GemmKernels.jl
-# that we can use to fuse the operations till we get CUBLASLt working.
+# Turns out NVIDIA has been shipping a bunch of fused kernels for a while now. We use
+# fuse all the operations into a single kernel.
 
 @inline function __fused_dense_bias_activation_impl(
         act::F, weight::AbstractMatrix, x::AbstractMatrix,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -199,3 +199,6 @@ CRC.@non_differentiable __maybe_reduce_BLAS_threads(::AbstractArray)
 end
 
 CRC.@non_differentiable __reset_BLAS_threads(::Int)
+
+# Defined in ext/LuxLibCUDAExt.jl
+function _cublaslt_matmul_fused! end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -135,7 +135,7 @@ end
 end
 @inline function __fast_broadcast!(f::F, x, args...) where {F}
     if ArrayInterface.fast_scalar_indexing(x)
-        if maximum(length, (x, args...)) > 20_000
+        if maximum(length, (x, args...)) > 200_000
             @strided x .= f.(x, args...)
         else
             @.. x = f(x, args...)
@@ -150,7 +150,7 @@ end
 end
 @inline function __nonuniform_fast_broadcast!(f::F, x, args...) where {F}
     if ArrayInterface.fast_scalar_indexing(x)
-        if maximum(length, (x, args...)) > 20_000
+        if maximum(length, (x, args...)) > 200_000
             @strided x .= f.(x, args...)
         else
             @. x = f(x, args...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -169,7 +169,7 @@ end
 
 @inline __added_bias_gradient(::Nothing, _) = CRC.NoTangent()
 @inline function __added_bias_gradient(b::AbstractArray, Δ)
-    ∂b = similar(b)
+    ∂b = similar(b, promote_type(eltype(b), eltype(Δ)))
     sum!(∂b, Δ)
     return ∂b
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -74,6 +74,7 @@ end
 # Maybe typecast the array
 @inline _oftype_array(::Type{T}, x::AbstractArray{T}) where {T} = x
 @inline _oftype_array(::Type{T}, x::AbstractArray) where {T} = T.(x)
+@inline _oftype_array(::Type{T}, ::Nothing) where {T} = nothing
 
 ## This part is taken from NNlib.jl
 # This just saves typing `only.(only.(` many times:

--- a/test/conv_tests.jl
+++ b/test/conv_tests.jl
@@ -80,8 +80,9 @@
             else
                 # FiniteDiffencing doesn't work great for MP because of how LuxTestUtils is
                 # implemented.
-                @eval @test_gradients $__f $activation $weight $x $bias $cdims gpu_testing=$on_gpu soft_fail=$fp16 atol=$atol rtol=$rtol skip_finite_differences=$(Tx !=
-                                                                                                                                                                   Tw)
+                @eval @test_gradients $__f $activation $weight $x $bias $cdims gpu_testing=$on_gpu soft_fail=$fp16 atol=$atol rtol=$rtol skip_reverse_diff=$(Tx !=
+                                                                                                                                                             Tw) skip_finite_differences=$(Tx !=
+                                                                                                                                                                                           Tw)
             end
         end
     end

--- a/test/dense_tests.jl
+++ b/test/dense_tests.jl
@@ -35,8 +35,9 @@
                 rtol = fp16 ? 1.0f-1 : 1.0f-3
                 # FiniteDiffencing doesn't work great for MP because of how LuxTestUtils is
                 # implemented.
-                @eval @test_gradients $__f $activation $w $x $bias gpu_testing=$on_gpu soft_fail=$fp16 atol=$atol rtol=$rtol skip_finite_differences=$(Tx !=
-                                                                                                                                                       Tw)
+                @eval @test_gradients $__f $activation $w $x $bias gpu_testing=$on_gpu soft_fail=$fp16 atol=$atol rtol=$rtol skip_reverse_diff=$(Tx !=
+                                                                                                                                                 Tw) skip_finite_differences=$(Tx !=
+                                                                                                                                                                               Tw)
             end
         end
     end


### PR DESCRIPTION
- [x] Overload forward diff for fused conv. Use slower fallback but that is fine for now
- [x] Start using CUBLASLt. Fixes #56 
  - [x] Mixed Precision - Hijack the external API to forward them to cuBLASLt
  - [x] Forward Pass
  - [x] ForwardDiff patch to use the fallback?
  - [x] Backward Pass caching via `_AUX` descriptors -- only needs to be done for `gelu`, we already handle other cases efficiently. No reason to complicate it with a call to cublasLt
    - [x] Inspect the gradients modes to ensure they don't fused the matmuls
- [x] Mixed Precision also used the fused ops (except if it involves dual numbers)