### PR TITLE
Add an alternate broadcast path for activation gradient

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxLib"
 uuid = "82251201-b29d-42c6-8e01-566dec8acb11"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.3.19"
+version = "0.3.20"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -192,6 +192,16 @@ end
     return @. Δ * only_derivative(out, act, x)
 end
 
+@inline function __activation_gradient_simple(Δ, out, act::F, x) where {F}
+    return @. Δ * only_derivative(out, act, x)
+end
+
+# Needed for reverse over reverse mode AD
+function CRC.rrule(cfg::CRC.RuleConfig{>:CRC.HasReverseMode},
+        ::typeof(__activation_gradient), Δ, out, act::F, x) where {F}
+    return CRC.rrule_via_ad(cfg, __activation_gradient_simple, Δ, out, act, x)
+end
+
 # Reduce BLAS threads if we are going to use a native Julia implementation
 @inline function __maybe_reduce_BLAS_threads(x::AbstractArray)::Int
     if ArrayInterface.fast_scalar_indexing(x)


### PR DESCRIPTION
Bypasses the problem in https://github.com/LuxDL/Lux.jl/issues/610, but doesn't really solve the main problem. The remaining errors are on Zygote end.