### PR TITLE
fix: unfuse the broadcast add in generic path

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxLib"
 uuid = "82251201-b29d-42c6-8e01-566dec8acb11"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.3.31"
+version = "0.3.32"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/impl/bias_activation.jl
+++ b/src/impl/bias_activation.jl
@@ -21,7 +21,8 @@ __generic_bias_activation(::typeof(identity), x::AbstractArray{<:Number}, ::Noth
 __generic_bias_activation(σ::F, x::AbstractArray{<:Number}, ::Nothing) where {F} = σ.(x)
 function __generic_bias_activation(
         σ::F, x::AbstractArray{<:Number, N}, bias::AbstractVector{<:Number}) where {F, N}
-    return broadcast(σ ∘ +, x, __reshape_bias_into_xdims(x, bias))
+    bias_ = __reshape_bias_into_xdims(x, bias)
+    return @. σ(x + bias_)
 end
 
 # Entry Points to the implementation


### PR DESCRIPTION
This seems to cause extremely high compile times for ReverseDiff, mostly because it makes the tracked array into a Array of TrackedReals.