### PR TITLE
perf: fusing activation functions and other misc perf improvements

### DIFF
--- a/benchmarks/setup.jl
+++ b/benchmarks/setup.jl
@@ -30,17 +30,17 @@ function setup_benchmarks!(suite::BenchmarkGroup, backend::String, num_cpu_threa
     cpu_or_gpu = backend == "CPU" ? "CPU" : "GPU"
     final_backend = backend == "CPU" ? string(num_cpu_threads, " ", "thread(s)") : backend
 
-    # setup_dense_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
+    setup_dense_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
 
     setup_bias_activation_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
 
     setup_batchnorm_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
 
-    # setup_layernorm_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
+    setup_layernorm_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
 
-    # setup_groupnorm_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
+    setup_groupnorm_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
 
-    # setup_batched_matmul_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
+    setup_batched_matmul_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
 end
 
 # Dense

--- a/benchmarks/setup.jl
+++ b/benchmarks/setup.jl
@@ -30,17 +30,17 @@ function setup_benchmarks!(suite::BenchmarkGroup, backend::String, num_cpu_threa
     cpu_or_gpu = backend == "CPU" ? "CPU" : "GPU"
     final_backend = backend == "CPU" ? string(num_cpu_threads, " ", "thread(s)") : backend
 
-    setup_dense_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
+    # setup_dense_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
 
     setup_bias_activation_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
 
     setup_batchnorm_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
 
-    setup_layernorm_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
+    # setup_layernorm_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
 
-    setup_groupnorm_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
+    # setup_groupnorm_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
 
-    setup_batched_matmul_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
+    # setup_batched_matmul_benchmarks!(suite, cpu_or_gpu, final_backend, dev)
 end
 
 # Dense

--- a/src/impl/activation.jl
+++ b/src/impl/activation.jl
@@ -158,6 +158,7 @@ using ChainRulesCore: ChainRulesCore
 using EnzymeCore: EnzymeCore, EnzymeRules
 using NNlib: NNlib
 using SLEEFPirates: SLEEFPirates
+using Static: True
 
 using ....LuxLib: Numeric, Traits
 

--- a/src/impl/activation.jl
+++ b/src/impl/activation.jl
@@ -159,7 +159,7 @@ using EnzymeCore: EnzymeCore, EnzymeRules
 using NNlib: NNlib
 using SLEEFPirates: SLEEFPirates
 
-using ....LuxLib: Numeric
+using ....LuxLib: Numeric, Traits
 
 const CRC = ChainRulesCore
 
@@ -252,5 +252,9 @@ end
 fast_act(f::F) where {F} = f
 
 CRC.@non_differentiable fast_act(::Any...)
+
+for act in (:sigmoid_fast, :swish, :lisht, :tanh_fast, :tanh)
+    @eval Traits.fuse_cpu_activation(::typeof($act)) = True()
+end
 
 end

--- a/src/impl/activation.jl
+++ b/src/impl/activation.jl
@@ -98,9 +98,7 @@ end
 function activation_loop!(y::AbstractArray, σ::F, x::AbstractArray) where {F}
     # We use fuse activation as a proxy check for "simple functions"
     if LV.check_args(y, x) && Utils.known(!Traits.fuse_cpu_activation(σ))
-        @tturbo for I in indices((y, x))
-            y[I] = σ(x[I])
-        end
+        LV.vmap!(σ, y, x)
         return
     end
     activation_simd_loop!(y, σ, x)

--- a/src/impl/activation.jl
+++ b/src/impl/activation.jl
@@ -156,9 +156,8 @@ using ChainRulesCore: ChainRulesCore
 using EnzymeCore: EnzymeCore, EnzymeRules
 using NNlib: NNlib
 using SLEEFPirates: SLEEFPirates
-using Static: True
 
-using ....LuxLib: Numeric, Traits
+using ....LuxLib: Numeric
 
 const CRC = ChainRulesCore
 
@@ -251,9 +250,5 @@ end
 fast_act(f::F) where {F} = f
 
 CRC.@non_differentiable fast_act(::Any...)
-
-for act in (:sigmoid_fast, :swish, :lisht, :tanh_fast, :tanh)
-    @eval Traits.fuse_cpu_activation(::typeof($act)) = True()
-end
 
 end

--- a/src/impl/batchnorm.jl
+++ b/src/impl/batchnorm.jl
@@ -88,9 +88,9 @@ function batchnorm_affine_normalize_internal!(
     fuse_act = Traits.fuse_cpu_activation(act)
 
     if Utils.known(fuse_act)
-        apply_batchnorm_scale_bias_act!(y, γ′, β′, x, act)
+        apply_batchnorm_scale_bias_act_cpu!(y, γ′, β′, x, act)
     else
-        apply_batchnorm_scale_bias!(y, γ′, β′, x)
+        apply_batchnorm_scale_bias_cpu!(y, γ′, β′, x)
         activation!(y, opmode, act, y)
     end
 
@@ -111,16 +111,17 @@ function compute_batchnorm_scale_bias!(γ′, β′, γ, β, μ, σ², ϵ)
     end
 end
 
-function apply_batchnorm_scale_bias_act!(y::AbstractArray{<:Number, 3}, γ′::AbstractVector,
+function apply_batchnorm_scale_bias_act_cpu!(
+        y::AbstractArray{<:Number, 3}, γ′::AbstractVector,
         β′::AbstractVector, x::AbstractArray{<:Number, 3}, σ::F) where {F}
     if size(y, 1) == 1
-        apply_batchnorm_scale_bias_act_2d_serial!(y, γ′, β′, x, σ)
+        apply_batchnorm_scale_bias_act_2d_serial_cpu!(y, γ′, β′, x, σ)
     else
-        apply_batchnorm_scale_bias_act_3d_threaded!(y, γ′, β′, x, σ)
+        apply_batchnorm_scale_bias_act_3d_threaded_cpu!(y, γ′, β′, x, σ)
     end
 end
 
-@inline function apply_batchnorm_scale_bias_act_2d_serial!(
+@inline function apply_batchnorm_scale_bias_act_2d_serial_cpu!(
         y::AbstractArray{<:Number, 3}, γ′::AbstractVector,
         β′::AbstractVector, x::AbstractArray{<:Number, 3}, σ::F) where {F}
     for K in indices((x, y), 3)
@@ -130,7 +131,7 @@ end
     end
 end
 
-@inline function apply_batchnorm_scale_bias_act_3d_threaded!(
+@inline function apply_batchnorm_scale_bias_act_3d_threaded_cpu!(
         y::AbstractArray{<:Number, 3}, γ′::AbstractVector,
         β′::AbstractVector, x::AbstractArray{<:Number, 3}, σ::F) where {F}
     @batch for K in indices((x, y), 3)
@@ -142,7 +143,7 @@ end
     end
 end
 
-@inline function apply_batchnorm_scale_bias_act_3d_serial!(
+@inline function apply_batchnorm_scale_bias_act_3d_serial_cpu!(
         y::AbstractArray{<:Number, 3}, γ′::AbstractVector,
         β′::AbstractVector, x::AbstractArray{<:Number, 3}, σ::F) where {F}
     for K in indices((x, y), 3)
@@ -154,18 +155,18 @@ end
     end
 end
 
-Utils.@enzyme_reverse_alternative apply_batchnorm_scale_bias_act_3d_threaded! apply_batchnorm_scale_bias_act_3d_serial!
+Utils.@enzyme_reverse_alternative apply_batchnorm_scale_bias_act_3d_threaded_cpu! apply_batchnorm_scale_bias_act_3d_serial_cpu!
 
-function apply_batchnorm_scale_bias!(y::AbstractArray{<:Number, 3}, γ′::AbstractVector,
+function apply_batchnorm_scale_bias_cpu!(y::AbstractArray{<:Number, 3}, γ′::AbstractVector,
         β′::AbstractVector, x::AbstractArray{<:Number, 3})
     if size(y, 1) == 1
-        apply_batchnorm_scale_bias_2d_serial!(y, γ′, β′, x)
+        apply_batchnorm_scale_bias_2d_serial_cpu!(y, γ′, β′, x)
     else
-        apply_batchnorm_scale_bias_3d_threaded!(y, γ′, β′, x)
+        apply_batchnorm_scale_bias_3d_threaded_cpu!(y, γ′, β′, x)
     end
 end
 
-@inline function apply_batchnorm_scale_bias_2d_serial!(
+@inline function apply_batchnorm_scale_bias_2d_serial_cpu!(
         y::AbstractArray{<:Number, 3}, γ′::AbstractVector,
         β′::AbstractVector, x::AbstractArray{<:Number, 3})
     for K in indices((x, y), 3)
@@ -175,7 +176,7 @@ end
     end
 end
 
-@inline function apply_batchnorm_scale_bias_3d_threaded!(
+@inline function apply_batchnorm_scale_bias_3d_threaded_cpu!(
         y::AbstractArray{<:Number, 3}, γ′::AbstractVector,
         β′::AbstractVector, x::AbstractArray{<:Number, 3})
     @batch for K in indices((x, y), 3)
@@ -187,7 +188,7 @@ end
     end
 end
 
-@inline function apply_batchnorm_scale_bias_3d_serial!(
+@inline function apply_batchnorm_scale_bias_3d_serial_cpu!(
         y::AbstractArray{<:Number, 3}, γ′::AbstractVector,
         β′::AbstractVector, x::AbstractArray{<:Number, 3})
     for K in indices((x, y), 3)
@@ -199,7 +200,7 @@ end
     end
 end
 
-Utils.@enzyme_reverse_alternative apply_batchnorm_scale_bias_3d_threaded! apply_batchnorm_scale_bias_3d_serial!
+Utils.@enzyme_reverse_alternative apply_batchnorm_scale_bias_3d_threaded_cpu! apply_batchnorm_scale_bias_3d_serial_cpu!
 
 function batchnorm_affine_normalize_internal!(
         y::AbstractArray{<:Number, 3}, ::GPUBroadcastOp, act::F,

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -59,6 +59,13 @@ function activation_has_rrule(::F, ::Type{T}) where {F, T}
         Utils.only_derivative, Tuple{T, F, T})))
 end
 
+# Which activations can be fused into a single kernel
+for act in (
+    :identity, :(NNlib.relu), :tanh, :(NNlib.sigmoid), :abs, :abs2, :(NNlib.tanh_fast))
+    @eval fuse_cpu_activation(::typeof($act)) = True()
+end
+fuse_cpu_activation(::F) where {F} = False()
+
 end
 
 module System

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -60,7 +60,7 @@ function activation_has_rrule(::F, ::Type{T}) where {F, T}
 end
 
 # Which activations can be fused into a single kernel
-for act in (:identity, :(NNlib.relu), :abs, :abs2, :(NNlib.tanh_fast))
+for act in (:identity, :(NNlib.relu), :abs, :abs2)
     @eval fuse_cpu_activation(::typeof($act)) = True()
 end
 fuse_cpu_activation(::F) where {F} = False()

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -60,8 +60,7 @@ function activation_has_rrule(::F, ::Type{T}) where {F, T}
 end
 
 # Which activations can be fused into a single kernel
-for act in (
-    :identity, :(NNlib.relu), :tanh, :(NNlib.sigmoid), :abs, :abs2, :(NNlib.tanh_fast))
+for act in (:identity, :(NNlib.relu), :abs, :abs2, :(NNlib.tanh_fast))
     @eval fuse_cpu_activation(::typeof($act)) = True()
 end
 fuse_cpu_activation(::F) where {F} = False()


### PR DESCRIPTION
## Changes

- [x] `bias_activation` perf has been fixed.
- [x] regression in `batchnorm` performance has been fixed.
  - [x] check LV for 4d inputs -- not needed, simply batch suffices
  - [x] reverse mode -- can't do parallel here. will lead to race conditions
  - [x] Enzyme patch for polyester
- [x] restore running all benchmarks before merging