### PR TITLE
perf: use `@strided` to reduce code duplication

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxLib"
 uuid = "82251201-b29d-42c6-8e01-566dec8acb11"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.3.48"
+version = "0.3.49"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -28,6 +28,7 @@ SLEEFPirates = "476501e8-09a2-5ece-8869-fb82de89a1fa"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 UnrolledUtilities = "0fe1646c-419e-43be-ac14-22321958931b"
 
 [weakdeps]
@@ -81,6 +82,7 @@ SLEEFPirates = "0.6.43"
 Static = "0.8.4, 1"
 StaticArraysCore = "1.4.3"
 Statistics = "1.10"
+Strided = "2"
 Tracker = "0.2.34"
 UnrolledUtilities = "0.1.2"
 cuDNN = "1.3"

--- a/src/impl/Impl.jl
+++ b/src/impl/Impl.jl
@@ -16,6 +16,7 @@ using KernelAbstractions: KernelAbstractions, @kernel, @Const, @index
 using LoopVectorization: LoopVectorization, @turbo, @tturbo, indices
 using Octavian: Octavian
 using Polyester: @batch
+using Strided: Strided, @strided
 
 using LinearAlgebra: LinearAlgebra, mul!
 using Random: Random, AbstractRNG, rand!

--- a/src/impl/activation.jl
+++ b/src/impl/activation.jl
@@ -121,18 +121,8 @@ end
 function ∇activation(::AbstractInternalArrayOpMode, Δ, out, act::F, x) where {F}
     return @. Δ * Utils.only_derivative(out, act, x)
 end
-@inbounds function ∇activation(::LoopedArrayOp, Δ, out, act::F, x) where {F}
-    y = similar(out)
-    if x isa Utils.NotaNumber
-        @simd ivdep for i in indices((Δ, out))
-            @inbounds y[i] = Utils.only_derivative(out[i], act, x) * Δ[i]
-        end
-    else
-        @simd ivdep for i in indices((Δ, out, x))
-            @inbounds y[i] = Utils.only_derivative(out[i], act, x[i]) * Δ[i]
-        end
-    end
-    return y
+function ∇activation(::LoopedArrayOp, Δ, out, act::F, x) where {F}
+    return @strided @. Δ * Utils.only_derivative(out, act, x)
 end
 
 # Switch some of the activations to use SLEEFPirates.jl if needed

--- a/src/impl/activation.jl
+++ b/src/impl/activation.jl
@@ -122,7 +122,11 @@ function ∇activation(::AbstractInternalArrayOpMode, Δ, out, act::F, x) where 
     return @. Δ * Utils.only_derivative(out, act, x)
 end
 function ∇activation(::LoopedArrayOp, Δ, out, act::F, x) where {F}
-    return @strided @. Δ * Utils.only_derivative(out, act, x)
+    if Utils.can_strided(Δ)
+        return @strided @. Δ * Utils.only_derivative(out, act, x)
+    else
+        return @. Δ * Utils.only_derivative(out, act, x)
+    end
 end
 
 # Switch some of the activations to use SLEEFPirates.jl if needed

--- a/src/impl/batchnorm.jl
+++ b/src/impl/batchnorm.jl
@@ -86,120 +86,28 @@ function batchnorm_affine_normalize_internal!(
 
     compute_batchnorm_scale_bias!(γ′, β′, γ, β, μ, σ², ϵ)
 
+    γ′′ = reshape(γ′, 1, :, 1)
+    β′′ = reshape(β′, 1, :, 1)
     if Utils.known(Traits.fuse_cpu_activation(act))
-        apply_batchnorm_scale_bias_act_cpu!(y, γ′, β′, x, act)
+        @strided @. y = act(x * γ′′ + β′′)
     else
-        apply_batchnorm_scale_bias_cpu!(y, γ′, β′, x)
+        @strided @. y = x * γ′′ + β′′
         activation!(y, opmode, act, y)
     end
+    return
+end
 
+function compute_batchnorm_scale_bias!(γ′, β′, ::Nothing, ::Nothing, μ, σ², ϵ)
+    @strided @. γ′ = inv(sqrt(σ² + ϵ))
+    @strided @. β′ = -μ * γ′
     return
 end
 
 function compute_batchnorm_scale_bias!(γ′, β′, γ, β, μ, σ², ϵ)
-    if γ === nothing && β === nothing
-        @simd ivdep for J in indices((γ′, β′, μ, σ²))
-            @fastmath @inbounds γ′[J] = inv(sqrt(σ²[J] + ϵ))
-            @fastmath @inbounds β′[J] = -μ[J] * γ′[J]
-        end
-    else
-        @simd ivdep for J in indices((γ′, β′, γ, β, μ, σ²))
-            @fastmath @inbounds γ′[J] = γ[J] / sqrt(σ²[J] + ϵ)
-            @fastmath @inbounds β′[J] = β[J] - μ[J] * γ′[J]
-        end
-    end
+    @strided @. γ′ = γ / sqrt(σ² + ϵ)
+    @strided @. β′ = β - μ * γ′
+    return
 end
-
-function apply_batchnorm_scale_bias_act_cpu!(
-        y::AbstractArray{yT, 3}, γ′::AbstractVector, β′::AbstractVector,
-        x::AbstractArray{xT, 3}, σ::F) where {F, xT, yT}
-    if size(y, 1) == 1
-        apply_batchnorm_scale_bias_act_2d_serial_cpu!(y, γ′, β′, x, σ)
-    else
-        apply_batchnorm_scale_bias_act_3d_threaded_cpu!(y, γ′, β′, x, σ)
-    end
-end
-
-@inline function apply_batchnorm_scale_bias_act_2d_serial_cpu!(
-        y::AbstractArray{yT, 3}, γ′::AbstractVector, β′::AbstractVector,
-        x::AbstractArray{xT, 3}, σ::F) where {F, xT, yT}
-    for K in indices((x, y), 3)
-        @simd ivdep for J in indices((x, y, γ′, β′), (2, 2, 1, 1))
-            @fastmath @inbounds y[1, J, K] = σ(x[1, J, K] * γ′[J] + β′[J])
-        end
-    end
-end
-
-@inline function apply_batchnorm_scale_bias_act_3d_threaded_cpu!(
-        y::AbstractArray{yT, 3}, γ′::AbstractVector, β′::AbstractVector,
-        x::AbstractArray{xT, 3}, σ::F) where {F, xT, yT}
-    @batch for K in indices((x, y), 3)
-        for J in indices((x, y, γ′, β′), (2, 2, 1, 1))
-            @simd ivdep for I in indices((x, y), 1)
-                @fastmath @inbounds y[I, J, K] = σ(x[I, J, K] * γ′[J] + β′[J])
-            end
-        end
-    end
-end
-
-@inline function apply_batchnorm_scale_bias_act_3d_serial_cpu!(
-        y::AbstractArray{yT, 3}, γ′::AbstractVector, β′::AbstractVector,
-        x::AbstractArray{xT, 3}, σ::F) where {F, xT, yT}
-    for K in indices((x, y), 3)
-        for J in indices((x, y, γ′, β′), (2, 2, 1, 1))
-            @simd ivdep for I in indices((x, y), 1)
-                @fastmath @inbounds y[I, J, K] = σ(x[I, J, K] * γ′[J] + β′[J])
-            end
-        end
-    end
-end
-
-Utils.@enzyme_reverse_alternative apply_batchnorm_scale_bias_act_3d_threaded_cpu! apply_batchnorm_scale_bias_act_3d_serial_cpu!
-
-function apply_batchnorm_scale_bias_cpu!(y::AbstractArray{yT, 3}, γ′::AbstractVector,
-        β′::AbstractVector, x::AbstractArray{xT, 3}) where {xT, yT}
-    if size(y, 1) == 1
-        apply_batchnorm_scale_bias_2d_serial_cpu!(y, γ′, β′, x)
-    else
-        apply_batchnorm_scale_bias_3d_threaded_cpu!(y, γ′, β′, x)
-    end
-end
-
-@inline function apply_batchnorm_scale_bias_2d_serial_cpu!(
-        y::AbstractArray{yT, 3}, γ′::AbstractVector, β′::AbstractVector,
-        x::AbstractArray{xT, 3}) where {xT, yT}
-    for K in indices((x, y), 3)
-        @simd ivdep for J in indices((x, y, γ′, β′), (2, 2, 1, 1))
-            @fastmath @inbounds y[1, J, K] = x[1, J, K] * γ′[J] + β′[J]
-        end
-    end
-end
-
-@inline function apply_batchnorm_scale_bias_3d_threaded_cpu!(
-        y::AbstractArray{yT, 3}, γ′::AbstractVector, β′::AbstractVector,
-        x::AbstractArray{xT, 3}) where {xT, yT}
-    @batch for K in indices((x, y), 3)
-        for J in indices((x, y, γ′, β′), (2, 2, 1, 1))
-            @simd ivdep for I in indices((x, y), 1)
-                @fastmath @inbounds y[I, J, K] = x[I, J, K] * γ′[J] + β′[J]
-            end
-        end
-    end
-end
-
-@inline function apply_batchnorm_scale_bias_3d_serial_cpu!(
-        y::AbstractArray{yT, 3}, γ′::AbstractVector, β′::AbstractVector,
-        x::AbstractArray{xT, 3}) where {xT, yT}
-    for K in indices((x, y), 3)
-        for J in indices((x, y, γ′, β′), (2, 2, 1, 1))
-            @simd ivdep for I in indices((x, y), 1)
-                @fastmath @inbounds y[I, J, K] = x[I, J, K] * γ′[J] + β′[J]
-            end
-        end
-    end
-end
-
-Utils.@enzyme_reverse_alternative apply_batchnorm_scale_bias_3d_threaded_cpu! apply_batchnorm_scale_bias_3d_serial_cpu!
 
 function batchnorm_affine_normalize_internal!(
         y::AbstractArray{yT, 3}, ::GPUBroadcastOp, act::F, x::AbstractArray{xT, 3},
@@ -281,105 +189,44 @@ function CRC.rrule(
     return z, ∇batchnorm_affine_normalize_internal
 end
 
-function ∇batchnorm_affine_normalize(opmode::LoopedArrayOp, ∂y::AbstractArray{∂yT, 3},
+function ∇batchnorm_affine_normalize(::LoopedArrayOp, ∂y::AbstractArray{∂yT, 3},
         x::AbstractArray{xT, 3}, μ::AbstractVector, σ²::AbstractVector,
-        γ::Optional{<:AbstractVector}, β::Optional{<:AbstractVector}, ϵ::Real,
-        γ′::AbstractVector) where {∂yT, xT}
-    ∂x, ∂μ, ∂σ² = similar(x), similar(μ), similar(σ²)
-    ∂γ = γ === nothing ? nothing : similar(γ)
-    ∂β = β === nothing ? nothing : similar(β)
+        ::Nothing, ::Nothing, ϵ::Real, γ′::AbstractVector) where {∂yT, xT}
+    idenom = reshape(γ′, 1, :, 1)
+    idenom² = @strided @. idenom^2
+    μ′ = reshape(μ, 1, :, 1)
+    xμ = @strided @. x - μ′
 
-    ∇batchnorm_affine_normalize_cpu!(∂x, ∂μ, ∂σ², ∂γ, ∂β, ∂y, x, μ, σ², γ, ϵ, γ′)
+    ∂x = @strided @. ∂y * idenom
+    ∂μ = @strided mapreduce(-, +, ∂x; dims=(1, 3))
 
-    ∂γ = γ === nothing ? ∂∅ : ∂γ
-    ∂β = β === nothing ? ∂∅ : ∂β
+    ∂σ²_full = @strided @. ∂x * xμ * idenom² / 2
+    ∂σ² = @strided mapreduce(-, +, ∂σ²_full; dims=(1, 3))
 
-    return ∂x, ∂μ, ∂σ², ∂γ, ∂β
+    return ∂x, vec(∂μ), vec(∂σ²), ∂∅, ∂∅
 end
 
-function ∇batchnorm_affine_normalize_cpu!(
-        ∂x::AbstractArray{∂xT, 3}, ∂μ::AbstractVector{∂μT},
-        ∂σ²::AbstractVector{∂σ²T}, ::Nothing, ::Nothing, ∂y::AbstractArray{∂yT, 3},
-        x::AbstractArray{xT, 3}, μ::AbstractVector, σ²::AbstractVector, ::Nothing,
-        ϵ::Real, γ′::AbstractVector) where {∂xT, ∂μT, ∂σ²T, ∂yT, xT}
-    half = eltype(∂σ²)(0.5)
+function ∇batchnorm_affine_normalize(::LoopedArrayOp, ∂y::AbstractArray{∂yT, 3},
+        x::AbstractArray{xT, 3}, μ::AbstractVector, σ²::AbstractVector,
+        γ::AbstractVector, β::AbstractVector, ϵ::Real, γ′::AbstractVector) where {∂yT, xT}
+    idenom = reshape(@strided(@.(inv(sqrt(σ² + ϵ)))), 1, :, 1)
+    idenom² = @strided @. idenom^2
+    μ′ = reshape(μ, 1, :, 1)
+    xμ = @strided @. x - μ′
+    γ′′ = reshape(γ′, 1, :, 1)
 
-    fill!(∂μ, 0)
-    fill!(∂σ², 0)
+    ∂x = @strided @. ∂y * γ′′
+    ∂μ = @strided mapreduce(-, +, ∂x; dims=(1, 3))
 
-    if size(∂y, 1) == 1
-        @fastmath @inbounds for K in indices(∂y, 3)
-            @simd for J in indices(∂y, 2)
-                idenom = γ′[J]
-                idenom² = idenom^2
+    ∂σ²_full = @strided @. ∂x * xμ * idenom² / 2
+    ∂σ² = @strided mapreduce(-, +, ∂σ²_full; dims=(1, 3))
 
-                xμ = x[1, J, K] - μ[J]
+    ∂γ_full = @strided @. ∂y * xμ * idenom
+    ∂γ = @strided sum(∂γ_full; dims=(1, 3))
 
-                ∂x[1, J, K] = ∂y[1, J, K] * idenom
-                ∂μ[J] -= ∂x[1, J, K]
-                ∂σ²[J] -= ∂x[1, J, K] * xμ * half * idenom²
-            end
-        end
-    else
-        @fastmath @inbounds for K in indices(∂y, 3), J in indices(∂y, 2)
-            idenom = γ′[J]
-            idenom² = idenom^2
+    ∂β = @strided sum(∂y; dims=(1, 3))
 
-            @simd for I in indices(∂y, 1)
-                xμ = x[I, J, K] - μ[J]
-
-                ∂x[I, J, K] = ∂y[I, J, K] * idenom
-                ∂μ[J] -= ∂x[I, J, K]
-                ∂σ²[J] -= ∂x[I, J, K] * xμ * half * idenom²
-            end
-        end
-    end
-end
-
-function ∇batchnorm_affine_normalize_cpu!(
-        ∂x::AbstractArray{∂xT, 3}, ∂μ::AbstractVector{∂μT},
-        ∂σ²::AbstractVector{∂σ²T}, ∂γ::AbstractVector{∂γT},
-        ∂β::AbstractVector{∂βT}, ∂y::AbstractArray{∂yT, 3}, x::AbstractArray{xT, 3},
-        μ::AbstractVector, σ²::AbstractVector, γ::AbstractVector, ϵ::Real,
-        γ′::AbstractVector) where {∂xT, ∂μT, ∂σ²T, ∂γT, ∂βT, ∂yT, xT}
-    half = eltype(∂σ²)(0.5)
-
-    fill!(∂μ, 0)
-    fill!(∂σ², 0)
-    fill!(∂γ, 0)
-    fill!(∂β, 0)
-
-    if size(∂y, 1) == 1
-        @fastmath @inbounds for K in indices(∂y, 3)
-            @simd for J in indices(∂y, 2)
-                idenom = inv(sqrt(σ²[J] + ϵ))
-                idenom² = idenom^2
-
-                xμ = x[1, J, K] - μ[J]
-
-                ∂x[1, J, K] = ∂y[1, J, K] * γ′[J]
-                ∂μ[J] -= ∂x[1, J, K]
-                ∂σ²[J] -= ∂x[1, J, K] * xμ * half * idenom²
-                ∂γ[J] += ∂y[1, J, K] * xμ * idenom
-                ∂β[J] += ∂y[1, J, K]
-            end
-        end
-    else
-        @fastmath @inbounds for K in indices(∂y, 3), J in indices(∂y, 2)
-            idenom = inv(sqrt(σ²[J] + ϵ))
-            idenom² = idenom^2
-
-            @simd for I in indices(∂y, 1)
-                xμ = x[I, J, K] - μ[J]
-
-                ∂x[I, J, K] = ∂y[I, J, K] * γ′[J]
-                ∂μ[J] -= ∂x[I, J, K]
-                ∂σ²[J] -= ∂x[I, J, K] * xμ * half * idenom²
-                ∂γ[J] += ∂y[I, J, K] * xμ * idenom
-                ∂β[J] += ∂y[I, J, K]
-            end
-        end
-    end
+    return ∂x, vec(∂μ), vec(∂σ²), vec(∂γ), vec(∂β)
 end
 
 function ∇batchnorm_affine_normalize(

--- a/src/impl/common_ops.jl
+++ b/src/impl/common_ops.jl
@@ -46,10 +46,10 @@ function CRC.rrule(::typeof(mean_var), x::AbstractArray; dims=:, corrected::Bool
     ∇mean_var = @closure Δ -> begin
         ∂μ, ∂σ² = CRC.unthunk(Δ)
         n = dims_denom(x, dims)
-        ∂x₁ = unsum(x, CRC.unthunk(∂μ) / n, dims)
+        ∂x₁ = unsum(x, ∂μ / n, dims)
         pre = 2 // (dims_denom(x, dims) - corrected)
-        ∂x₂ = pre .* CRC.unthunk(∂σ²) .* (x .- μ)
-        return NoTangent(), 𝒫x(add!!(∂x₁, ∂x₂))
+        ∂x₂ = @. pre * ∂σ² * (x - μ)
+        return ∂∅, 𝒫x(add!!(∂x₁, ∂x₂))
     end
 
     return (μ, σ²), ∇mean_var

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,6 +9,8 @@ using LinearAlgebra: LinearAlgebra, BLAS
 using MLDataDevices: get_device_type, CPUDevice
 using NNlib: NNlib
 using Static: Static, False, True
+using Strided: maybestrided
+using UnrolledUtilities: unrolled_all
 
 using ..LuxLib: Optional, ∂∅
 
@@ -230,6 +232,14 @@ end
     kernel(args...)
     return
 end
+
+function can_strided(x)
+    return isconcretetype(Core.Compiler._return_type(maybestrided, Tuple{typeof(x)}))
+end
+
+can_strided(xs...) = unrolled_all(can_strided, xs)
+
+CRC.@non_differentiable can_strided(::Any...)
 
 end
 


### PR DESCRIPTION
## Operations Optimized

- `batchnorm`
- `activation` gradient
- `mean_var`

## Cleaner Implementations -- TODO

- strided cannot handle all array types what to do about that?
  - We manually check for `can_strided`. Too much code duplication. We can reuse the `@strided` macro code and redefine `maybe_strided` to not error for arrays not supported by StridedView

## TODOs

- `groupnorm`
- `activation`
- `bias_activation`
- does Enzyme work natively with strided? my guess would be yes